### PR TITLE
Add new `Queue#peekFirst()` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -18,6 +18,10 @@ class Queue {
 
     return undefined;
   }
+
+  peekFirst() {
+    return this._peek(this._head);
+  }
 }
 
 module.exports = Queue;

--- a/types/kiu.d.ts
+++ b/types/kiu.d.ts
@@ -3,7 +3,9 @@ declare namespace queue {
     new <T = any>(): Instance<T>;
   }
 
-  export interface Instance<T> {}
+  export interface Instance<T> {
+    peekFirst(): T | undefined;
+  }
 }
 
 declare namespace kiu {


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Queue#peekFirst()`

Returns the first value, located at the front of the queue, without mutating the queue itself. If the queue is empty, then `undefined` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
