### PR TITLE
Add new `Queue#peekLast()` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -22,6 +22,10 @@ class Queue {
   peekFirst() {
     return this._peek(this._head);
   }
+
+  peekLast() {
+    return this._peek(this._last);
+  }
 }
 
 module.exports = Queue;

--- a/types/kiu.d.ts
+++ b/types/kiu.d.ts
@@ -6,6 +6,7 @@ declare namespace queue {
   export interface Instance<T> {
     readonly length: number;
     peekFirst(): T | undefined;
+    peekLast(): T | undefined;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Queue#peekLast()`

Returns the last value, located at the rear of the queue, without mutating the queue itself. If the queue is empty, then `undefined` is returned.

Also, the corresponding TypeScript ambient declarations are included in the PR.
