### PR TITLE
Add new `Queue#isEmpty()` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -26,6 +26,10 @@ class Queue {
     return this;
   }
 
+  isEmpty() {
+    return !this._head && !this._last && this._length === 0;
+  }
+
   peekFirst() {
     return this._peek(this._head);
   }

--- a/types/kiu.d.ts
+++ b/types/kiu.d.ts
@@ -6,6 +6,7 @@ declare namespace queue {
   export interface Instance<T> {
     readonly length: number;
     clear(): this;
+    isEmpty(): boolean;
     peekFirst(): T | undefined;
     peekLast(): T | undefined;
   }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary predicate method: 

- `Queue#isEmpty()`

Determines whether the queue is empty, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
