### PR TITLE
Add new `Queue#forEach(fn)` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -42,6 +42,17 @@ class Queue {
     return this;
   }
 
+  forEach(fn) {
+    let {_head: item} = this;
+
+    while (item) {
+      fn(item.value);
+      item = item.next;
+    }
+
+    return this;
+  }
+
   isEmpty() {
     return !this._head && !this._last && this._length === 0;
   }

--- a/types/kiu.d.ts
+++ b/types/kiu.d.ts
@@ -7,6 +7,7 @@ declare namespace queue {
     readonly length: number;
     clear(): this;
     enqueue(value: T): this;
+    forEach(fn: (x: T) => void): this;
     isEmpty(): boolean;
     peekFirst(): T | undefined;
     peekLast(): T | undefined;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Queue#forEach(fn)`

Traverses the queue, from the front to the rear, and executes the provided `fn` function once for each traversed value, without mutating the queue. Returns the queue itself at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
