### PR TITLE
Add new `Queue#map(fn)` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -91,6 +91,18 @@ class Queue {
     return !this._head && !this._last && this._length === 0;
   }
 
+  map(fn) {
+    let {_head: current} = this;
+
+    while (current) {
+      const {next, value} = current;
+      current.value = fn(value);
+      current = next;
+    }
+
+    return this;
+  }
+
   peekFirst() {
     return this._peek(this._head);
   }

--- a/types/kiu.d.ts
+++ b/types/kiu.d.ts
@@ -11,6 +11,7 @@ declare namespace queue {
     forEach(fn: (x: T) => void): this;
     includes(value: T): boolean;
     isEmpty(): boolean;
+    map<U>(fn: (value: T) => U): Instance<U>;
     peekFirst(): T | undefined;
     peekLast(): T | undefined;
     reverse(): this;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Queue#map(fn)`

Traverses the queue, from front to rear, and mutates it by updating each stored value with the result of calling once the provided `fn` function on it. Returns the in-place mutated queue at the end of the traversal.

Also, the corresponding TypeScript ambient declarations are included in the PR.
