### PR TITLE
Add new `Queue#nth(n)` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -139,6 +139,10 @@ class Queue {
     return this;
   }
 
+  nth(n) {
+    return this._peek(this._nthItem(n));
+  }
+
   peekFirst() {
     return this._peek(this._head);
   }

--- a/types/kiu.d.ts
+++ b/types/kiu.d.ts
@@ -12,6 +12,7 @@ declare namespace queue {
     includes(value: T): boolean;
     isEmpty(): boolean;
     map<U>(fn: (value: T) => U): Instance<U>;
+    nth(n: number): T | undefined;
     peekFirst(): T | undefined;
     peekLast(): T | undefined;
     reverse(): this;


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Queue#nth(n)`

Traverses the queue, from front to rear, and returns the `nth` value. If the value does not exist, then `undefined` is returned. The queue values follow zero-based numbering, thus the first/initial value corresponds to index `0`.

Also, the corresponding TypeScript ambient declarations are included in the PR.
