### PR TITLE
Add new `Queue#rotateRight(n)` class method (#3)

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -188,6 +188,10 @@ class Queue {
     return this;
   }
 
+  rotateRight(n) {
+    return this._rotate(n);
+  }
+
   toArray() {
     const array = [];
     this.forEach(x => array.push(x));

--- a/types/kiu.d.ts
+++ b/types/kiu.d.ts
@@ -16,6 +16,7 @@ declare namespace queue {
     peekFirst(): T | undefined;
     peekLast(): T | undefined;
     reverse(): this;
+    rotateRight(n: number): this;
     toArray(): T[];
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new unary method: 

- `Queue#rotateRight(n)`

Mutates the queue by moving the `n` front-most items to the rear of the queue in a rotating fashion. Returns the queue itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
